### PR TITLE
fix broken deep links

### DIFF
--- a/modules/attributes/pages/document-attributes.adoc
+++ b/modules/attributes/pages/document-attributes.adoc
@@ -38,8 +38,8 @@ User-defined attributes:: #TBA#
 * have a value that xref:wrap-values.adoc[spans multiple, contiguous lines]
 * have a value that includes basic inline AsciiDoc syntax, such as:
 ** attribute references
-** text formatting (if wrapped in a xref:pass:pass-macro.adoc#pass-subs[pass macro])
-** inline macros (if wrapped in a xref:pass:pass-macro.adoc#pass-subs[pass macro])
+** text formatting (if wrapped in a xref:pass:pass-macro.adoc#inline-pass[pass macro])
+** inline macros (if wrapped in a xref:pass:pass-macro.adoc#inline-pass[pass macro])
 
 But there are certain limitations to be aware of.
 Document attributes cannot:

--- a/modules/blocks/pages/preamble-and-lead.adoc
+++ b/modules/blocks/pages/preamble-and-lead.adoc
@@ -34,7 +34,7 @@ The result of <<ex-lead>> is displayed below.
 
 image::lead.png[Paragraph styled with the lead role value,role=screenshot]
 
-When you convert a document to HTML using the default stylesheet, the first paragraph of the <<preamble,preamble>> is automatically styled as a lead paragraph.
+When you convert a document to HTML using the default stylesheet, the first paragraph of the <<preamble-style,preamble>> is automatically styled as a lead paragraph.
 To disable this behavior, assign any role to the first paragraph.
 
 .Disabling the automatic lead paragraph styling

--- a/modules/sections/pages/numbers.adoc
+++ b/modules/sections/pages/numbers.adoc
@@ -65,4 +65,4 @@ When the `doctype` is `book`, level-1 sections become xref:chapters.adoc[chapter
 Therefore, a `sectnumlevels` of `4` translates to 3 levels of numbered sections inside each chapter.
 
 Assigning `sectnumlevels` a value of `0` is effectively the same as disabling section numbering (`sectnums!`).
-However, if your document is a xref:parts.adoc[multi-part book] with xref:special-section-numbers.adoc#partnums[part numbering enabled], then you'd have to set `sectnumlevels` to `-1` to disable part numbering too (the equivalent of `partnums!`).
+However, if your document is a xref:parts.adoc[multi-part book] with xref:part-numbers-and-labels.adoc#partnums[part numbering enabled], then you'd have to set `sectnumlevels` to `-1` to disable part numbering too (the equivalent of `partnums!`).

--- a/modules/sections/pages/part-numbers-and-labels.adoc
+++ b/modules/sections/pages/part-numbers-and-labels.adoc
@@ -6,7 +6,6 @@
 Book part numbers are controlled by the `partnums` attribute, not `sectnums`.
 To autogenerate part numbers, set `partnums` in the book header.
 
-
 [source]
 ----
 = The Secret Manual

--- a/modules/sections/pages/section-ref.adoc
+++ b/modules/sections/pages/section-ref.adoc
@@ -6,7 +6,7 @@
 |===
 |Feature |Attribute |Value(s) |Notes
 
-|xref:appendix.adoc#prefix[Appendix label]
+|xref:appendix.adoc#caption[Appendix label]
 |`appendix-caption`
 |_Appendix_ (default) or user defined text
 |

--- a/modules/tables/pages/add-cells-and-rows.adoc
+++ b/modules/tables/pages/add-cells-and-rows.adoc
@@ -46,7 +46,7 @@ AsciiDoc provides operators to control the following cell properties:
 * xref:format-cell-content.adoc[content style]
 
 A cell specifier only applies to the cell it's placed on, not to all of the cells in the same row.
-Also, the operator in a cell specifier will override the operator in a xref:add-columns.adoc#col-specifier.adoc[column specifier] if they belong to the same property.
+Also, the operator in a cell specifier will override the operator in a xref:add-columns.adoc#col-specifier[column specifier] if they belong to the same property.
 
 == Create a table cell
 

--- a/modules/tables/pages/add-columns.adoc
+++ b/modules/tables/pages/add-columns.adoc
@@ -69,10 +69,10 @@ Since four consecutive cells are entered on the first line directly after the de
 |===
 
 As specified, the table includes four columns of equal width, a header row, and a regular row.
-Since all of the columns in <<ex-cols-table>> are assigned the same width via their column specifiers (i.e., `3`), the number of columns could be specified with a <<multiplier,column multiplier>>.
+Since all of the columns in <<ex-cols-table>> are assigned the same width via their column specifiers (i.e., `3`), the number of columns could be specified with a <<column-multiplier,column multiplier>>.
 Or, you could adjust the width of an individual column by xref:adjust-column-widths.adoc[increasing the numerical value of its specifier].
 
-[#multiplier]
+[#column-multiplier]
 === Using a column multiplier
 
 A [.term]*column multiplier* allows you to apply the same width, horizontal alignment, vertical alignment, and content style to multiple, consecutive columns in a table.

--- a/modules/tables/pages/build-a-basic-table.adoc
+++ b/modules/tables/pages/build-a-basic-table.adoc
@@ -77,7 +77,7 @@ It contains two columns and three rows of text positioned and styled using the d
 |Cell in column 1, row 3 |Cell in column 2, row 3
 |===
 
-In addition to the xref:add-columns.adoc[cols attribute], you can identify the number of columns using a xref:add-columns.adoc#multiplier[column multiplier] or xref:add-columns.adoc#implicit-cols[the table's first row].
+In addition to the xref:add-columns.adoc[cols attribute], you can identify the number of columns using a xref:add-columns.adoc#column-multiplier[column multiplier] or xref:add-columns.adoc#implicit-cols[the table's first row].
 However, the `cols` attribute is required to customize the xref:adjust-column-widths.adoc[width], xref:align-by-column.adoc[alignment], or xref:format-column-content.adoc[style] of a column.
 
 === Add a header row to the table

--- a/modules/text/pages/index.adoc
+++ b/modules/text/pages/index.adoc
@@ -66,7 +66,7 @@ She spells her name with an "`h`", as in Sara**h**.
 
 The unconstrained pair provides a more brute force approach to formatting at the tradeoff of being more verbose.
 You'll typically switch to an unconstrained pair when a constrained pair doesn't do the trick.
-See xref:troubleshoot-unconstrained-formatting.adoc#when-to-use-unconstrained[When should I use an unconstrained pair?] for more examples of when to use an unconstrained pair.
+See xref:troubleshoot-unconstrained-formatting.adoc#use-unconstrained[When should I use an unconstrained pair?] for more examples of when to use an unconstrained pair.
 
 == Inline text and punctuation styles
 


### PR DESCRIPTION
fix links to page fragments (aka deep links) by correcting the xref or updating the name of the anchor