### PR TITLE
resolves #24 rework reference table for built-in attributes

### DIFF
--- a/modules/attributes/pages/document-attributes-reference.adoc
+++ b/modules/attributes/pages/document-attributes-reference.adoc
@@ -1,502 +1,474 @@
 = Document Attributes Reference
+// TODO use icons or emoji for y and n
 :y: Yes
 :n: No
-:en: &#8211;
+:endash: &#8211;
 
-////
-Need to update the compatibility guide with:
+Document attributes are used either to configure behavior in the processor or to relay information about the document and its environment.
+This page catalogs all the built-in (i.e., reserved) document attributes in AsciiDoc.
 
-* numbered = sectnums
-* docinfo1 = docinfo
-* docinfo2 = docinfo
-* toc-class = use custom theme https://github.com/asciidoctor/asciidoctor.org/issues/379[issue #379]
-* toc-placement = toc
-* notitle = showtitle!
-* encoding = ignored always UTF-8
-////
+Unless otherwise marked, these attributes can be modified (set or unset) from the API using the `:attributes` option, from the CLI using the `-a` option, or in the document (often in the document header) using an attribute entry.
 
-Built-in document attributes can be set and unset using an attribute entry.
+Use the follow legend to understand the columns and values in the tables on this page.
 
-Automatically Set:: The attribute is set automatically by Asciidoctor and assigned its default value at processing time if you don't set it explicitly in the API, command line, or document.
-Automatically set attributes can be unset with the `!`.
+[horizontal]
+Set By Default:: The attribute is automatically set and assigned a default value by the AsciiDoc processor.
+The default value is indicated in *bold* (e.g., `*skip*`).
 
-Values::
+Allowable Values:: Allowable values for the attribute.
+Numeric values and values shown in _italic_ are instructional and indicate a value type (e.g., _any_, _empty_, _number_, 1{endash}5, etc.).
 +
-* _empty_ value: The _empty_ value indicates the attribute doesn't have an explicit value.
+* _any_ -- Any value is accepted.
+* _empty_ -- Indicates the attribute doesn't require an explicit value.
 The attribute is simply turned on by being set.
-* *default* value: Attributes that have built-in values may have a default value which is indicated by the *bolded value*.
-If you set the attribute but leave the value empty, Asciidoctor will fall back to this default value at processing time.
-* If the attribute doesn't accept an _empty_ value or have a *default* value, than you must explicitly assign the attribute an accepted built-in or user-defined value.
+* _empty_[=`effective`] -- In some cases, an empty value is interpreted by the processor as one of the allowable non-empty values.
+This effective value is prefixed with an equals sign and enclosed in square brackets (e.g., [=`auto`]).
+The effective value will not be visible to an attribute reference.
+* (`implied`) -- Built-in attributes that are not set may have an implied value.
+The implied value is enclosed in parentheses (e.g., (`attributes`)).
+An implied value cannot be resolved using an attribute reference.
 
-Header Set:: The attribute can be set and assigned a value (or unset) in the document's header.
-In almost all cases, these attributes can also be set, defined, or unset in the API or command line.
-If you set an attribute from the command line or API, it's defined for the whole document and can't be changed in the document header or body unless `@` is added to the end of the value.
-See xref:assignment-precedence.adoc[] for more information.
-The one exception to this rule is the `sectnums` attribute, which can always be changed.
++
+If the attribute doesn't accept _any_ or _empty_, than you must only assign one of the allowable values or specified value type.
 
-Body Set:: The attribute can be set, assigned a value, or unset in the document's body (anywhere below the document header).
-When you set an attribute in the body, it's visible from the point it's set until it's unset (unless it's overridden by the xref:assignment-precedence.adoc[assignment precedence]).
+Header Only:: The attribute must be set or unset by the end of the document header (i.e., set by the API, CLI, or in the document header).
+Otherwise, the assignment won't have any effect on the document.
+If an attribute is not marked as _Header Only_, it can be set anywhere in the document, assuming the attribute is not locked by the API or CLI.
+However, changing an attribute only affects behavior for content that follows the assignment (in document order).
 
 == Compliance attributes
 
-[%autowidth,cols="~m,^~,~,^~,^~,~"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |Header Set |Body Set  |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
 
 |attribute-missing
-|{n}
-|`*skip*` +
-`drop` +
+|`drop` +
 `drop-line` +
+`*skip*` +
 `warn`
 |{y}
-|{y}
+|{n}
 |Controls how xref:unresolved-references.adoc#missing[missing attribute references] are handled.
 
 |attribute-undefined
+|`drop` +
+`*drop-line*`
+|{y}
 |{n}
-|`*drop-line*` +
-`drop`
-|{y}
-|{y}
-|Controls how xref:unresolved-references.adoc#undefined[undefined attributes] are handled.
+|Controls how xref:unresolved-references.adoc#undefined[attribute unassignments] are handled.
 
 |compat-mode
+|_empty_
 |{n}
-e|empty
-|{y}
-|{y}
-|Controls when the legacy parser is used to parse the document.
+|{n}
+|Controls when the legacy parsing mode is used to parse the document.
 
 |experimental
+|_empty_
 |{n}
-e|empty
 |{y}
-|{n}
-|Enables xref:macros:ui-macros.adoc[] and xref:macros:keyboard-macro.adoc[].
+|Enables xref:macros:ui-macros.adoc[] and the xref:macros:keyboard-macro.adoc[].
 
 |reproducible
+|_empty_
 |{n}
-e|empty
 |{y}
-|{n}
 |Prevents last-updated date from being added to HTML footer or DocBook info element.
 Useful for storing the output in a source code control system as it prevents spurious changes every time you convert the document.
 //Alternatively, you can use the SOURCE_DATE_EPOCH environment variable to fix the value.
+
+|skip-front-matter
+|_empty_
+|{n}
+|{y}
+|Consume YAML-style frontmatter at top of document and store it in `front-matter` attribute.
+//<<front-matter-added-for-static-site-generators>>
 |===
 
 [#builtin-attributes-i18n]
-== Internationalization and numbering
+== Localization and numbering attributes
 
-[%autowidth,cols="~m,^~,~,^~,^~,~"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |Header Set |Body Set |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
 
 |appendix-caption
-|Only when section assigned `Appendix` style
-|`*Appendix*` +
-_user-defined_
+|_any_ +
+`*Appendix*`
 |{y}
-|{y}
+|{n}
 |Label added before an xref:sections:appendix.adoc[appendix title].
 
 |appendix-number
-|Only when section assigned `Appendix` style
-|`*A*` +
-_letter or number_
-|{y}
-|{y}
-|Stores appendix letter or number sequence start.
+|_character_ +
+(`@`)
+|{n}
+|{n}
+|Sets the seed value for the appendix number sequence.^[<<fn-number,1>>]^
 
 |appendix-refsig
-|
-|`*Appendix*` +
-_any_
+|_any_ +
+`*Appendix*`
 |{y}
-|{y}
+|{n}
 |Signifier added to Appendix title cross references.
 
 |caution-caption
+|_any_ +
+`*Caution*`
 |{y}
-|`*Caution*` +
-_any_
-|{y}
-|{y}
+|{n}
 |Text used to label CAUTION admonitions when icons aren't enabled.
 
 |chapter-number
-|Only when `doctype` is `book`
-|`*1*` +
-_number_
-|
-|
-|Stores chapter number sequence start.
+|_number_ +
+(0)
+|{n}
+|{n}
+|Sets the seed value for the chapter number sequence.^[<<fn-number,1>>]^
+_Book doctype only_.
 
 |chapter-refsig
-|
-|`*Chapter*` +
-_any_
+|_any_ +
+`*Chapter*`
 |{y}
-|{y}
+|{n}
 |Signifier added to Chapter titles in cross references.
+_Book doctype only_.
 
-|chapter-label
-|Only when `doctype` is `book`
-|`*Chapter*` +
-_any_
-|{y}
-|{y}
+|chapter-signifier
+|_any_
+|{n}
+|{n}
 |xref:sections:chapters.adoc[Label added to level-1 section titles (chapters)].
-_PDF converter only_.
 _Book doctype only_.
 
 |example-caption
+|_any_ +
+`*Example*`
 |{y}
-|`*Example*` +
-_any_
-|{y}
-|{y}
+|{n}
 |Text used to label example blocks.
 
 |example-number
-|{y}
-|`*1*` +
-_number_
-|
-|
-|Stores example number sequence start.
+|_number_ +
+(0)
+|{n}
+|{n}
+|Sets the seed value for the example number sequence.^[<<fn-number,1>>]^
 
 |figure-caption
+|_any_ +
+`*Figure*`
 |{y}
-|`*Figure*` +
-_any_
-|{y}
-|{y}
+|{n}
 |Text used to label images and figures.
 
 |figure-number
-|{y}
-|`*1*` +
-_number_
-|
-|
-|Stores figure number sequence start.
+|_number_ +
+(0)
+|{n}
+|{n}
+|Sets the seed value for the figure number sequence.^[<<fn-number,1>>]^
 
 |important-caption
+|_any_ +
+`*Important*`
 |{y}
-|`*Important*` +
-_any_
-|{y}
-|{y}
+|{n}
 |Text used to label IMPORTANT admonitions when icons are not enabled.
 
 |lang
-|
-|`*en*` +
-valid XML country code
+|_valid XML language code_ +
+(`en`)
+|{n}
 |{y}
-|
-|Language used on root element of the output document
+|Language used on root element of the output document.
 
 |last-update-label
-|
-|`*Last updated*`, _any_
+|_any_ +
+`*Last updated*`
 |{y}
-|
+|{y}
 |Text used for “Last updated” label in footer.
 
 |listing-caption
-|{n}
 |_any_
-|{y}
-|{y}
+|{n}
+|{n}
 |Text used to label listing blocks.
 
 |listing-number
-|
-|`*1*`, _number_
-|
-|
-|Stores listing number sequence start.
+|_number_ +
+(0)
+|{n}
+|{n}
+|Sets the seed value for the listing number sequence.^[<<fn-number,1>>]^
 
 |manname-title
-|
-|`*NAME*`, _any_
+|_any_ +
+(`Name`)
+|{n}
 |{y}
-|
 |Label for program name section in the man page.
 
 |nolang
-|{n}
 |_empty_
+|{n}
 |{y}
-|
 |Prevents `lang` attribute from being added to root element of the output document.
 
 |note-caption
+|_any_ +
+`*Note*`
 |{y}
-|`*Note*`, _any_
-|{y}
-|{y}
+|{n}
 |Text used to label NOTE admonitions when icons aren't enabled.
 
-|preface-title
+|part-refsig
+|_any_ +
+`*Part*`
+|{y}
 |{n}
+|Signifier added to Part titles in cross references.
+_Book doctype only_.
+
+|part-signifier
 |_any_
-|{y}
-|{y}
+|{n}
+|{n}
+|xref:sections:chapters.adoc[Label added to level-0 section titles (parts)].
+_Book doctype only_.
+
+|preface-title
+|_any_
+|{n}
+|{n}
 |Title text for an anonymous preface when `doctype` is `book`.
 
 |section-refsig
-|
-|`*Section*` +
-_any_
+|_any_ +
+`*Section*`
 |{y}
-|{y}
+|{n}
 |Signifier added to title of numbered sections in cross reference text.
 
 |table-caption
+|_any_ +
+`*Table*`
 |{y}
-|`*Table*` +
-_any_
-|{y}
-|{y}
+|{n}
 |Text of label prefixed to table titles.
 
 |table-number
-|{y}
-|`*1*` +
-_number_
-|{y}
-|{y}
-|Stores table number sequence start.
+|_number_ +
+(0)
+|{n}
+|{n}
+|Sets the seed value for the table number sequence.^[<<fn-number,1>>]^
 
 |tip-caption
+|_any_ +
+`*Tip*`
 |{y}
-|`*Tip*` +
-_any_
-|{y}
-|{y}
+|{n}
 |Text used to label TIP admonitions when icons aren't enabled.
 
 |toc-title
-|Only if `toc` is set
-|`*Table of Contents*` +
-_any_
+|_any_ +
+`*Table of Contents*`
 |{y}
-|
+|{y}
 |xref:toc:title.adoc[Title for table of contents].
 
 |untitled-label
-|
-|`*Untitled*` +
-_any_
+|_any_ +
+`*Untitled*`
 |{y}
-|
+|{y}
 |Default document title if document doesn't have a document title.
 
+|version-label
+|_any_ +
+`*Version*`
+|{y}
+|{y}
+|See xref:document:version-label.adoc[].
+
 |warning-caption
+|_any_ +
+`*Warning*`
 |{y}
-|`*Warning*` +
-_any_
-|{y}
-|{y}
+|{n}
 |Text used to label TIP admonitions when icons aren't enabled.
 |===
 
-== Header and metadata attributes
+== Document metadata attributes
 
-[cols="10m,^15,15,^5,^5,30"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |Header Set |Body Set |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
 
 |app-name
-|{n}
 |_any_
+|{n}
 |{y}
-|
 |Adds `application-name` meta element for mobile devices inside HTML document head.
 
 |author
-|Only if present in author info line
 |_any_
+|Extracted from author info line
 |{y}
-|{n}
 |Can be set automatically via the author info line or explicitly.
 See xref:document:author-information.adoc[].
 
 |authorinitials
-|Only if present in author info line or `author`
 |_any_
+|Extracted from `author` attribute
 |{y}
-|{n}
 |Derived from the author attribute by default.
 See xref:document:author-information.adoc[].
 
 |authors
-|Only if present in author info line
 |_any_
+|Extracted from author info line
 |{y}
-|{n}
 |Can be set automatically via the author info line or explicitly as a comma-separated value list.
 See xref:document:author-information.adoc[].
 
 |copyright
-|{n}
 |_any_
-|{y}
 |{n}
+|{y}
 |Adds `copyright` meta element in HTML document head.
 
 |doctitle
-|Only if document has a title (`=`)
 |_any_
+|Yes, if document has a doctitle
 |{y}
-|{n}
 |See xref:document:title.adoc#reference-doctitle[doctitle attribute].
 
 |description
-|{n}
 |_any_
-|{y}
 |{n}
+|{y}
 |Adds xref:document:metadata.adoc#description[description] meta element in HTML document head.
 
 |email
-|Only if present in author info line
 |_any_
+|Extracted from author info line
 |{y}
-|{n}
 |Can be any inline macro, such as a URL.
 See xref:document:author-information.adoc[].
 
 |firstname
-|Only if present in author info line
 |_any_
+|Extracted from author info line
 |{y}
-|{n}
 |See xref:document:author-information.adoc[].
 
 |front-matter
-|If front matter is captured
 |_any_
-|n/a
+|Yes, if front matter is captured
 |n/a
 |If `skip-front-matter` is set via the API or CLI, any YAML-style frontmatter skimmed from the top of the document is stored in this attribute.
 
 |keywords
-|{n}
 |_any_
-|{y}
 |{n}
+|{y}
 |Adds xref:document:metadata.adoc#keywords[keywords] meta element in HTML document head.
 
 |lastname
-|Only if present in author info line
 |_any_
+|Extracted from author info line
 |{y}
-|{n}
 |See xref:document:author-information.adoc[].
 
 |middlename
-|Only if present in author info line
 |_any_
+|Extracted from author info line
 |{y}
-|{n}
 |See xref:document:author-information.adoc[].
 
 |orgname
-|{n}
 |_any_
-|{y}
 |{n}
+|{y}
 |Adds `<orgname>` element value to DocBook info element.
 
 |revdate
-|Only if present in version info line
 |_any_
+|Extracted from revision info line
 |{y}
-|{n}
 |See xref:document:revision-information.adoc[].
 
 |revremark
-|Only if present in version info line
 |_any_
+|Extracted from revision info line
 |{y}
-|{n}
 |See xref:document:revision-information.adoc[].
 
 |revnumber
-|Only if present in version info line
 |_any_
+|Extracted from revision info line
 |{y}
-|{n}
 |See xref:document:revision-information.adoc[].
 
 |title
-|{n}
 |_any_
-|{y}
 |{n}
+|{y}
 |Value of `<title>` element in HTML `<head>` or main DocBook `<info>` of output document.
 Used as a fallback when the document title is not specified.
 See xref:document:title.adoc#title-attr[title attribute].
-
-|version-label
-|Only if `revnumber` is set
-|*Version*, _any_
-|{y}
-|
-|See xref:document:version-label.adoc[].
 |===
 
-== Section titles and table of contents attributes
+== Section title and table of contents attributes
 
-[cols="10m,^15,15,^5,^5,30"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |Header Set |Body Set |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
 
 |idprefix
-|{y}
-|*_*, valid XML ID start character
+|_valid XML ID start character_ +
+`*_*`
 |{y}
 |{n}
 |Prefix of auto-generated section IDs.
 See xref:sections:id-prefix-and-separator.adoc#prefix[Change the ID prefix].
 
 |idseparator
-|{y}
-|*_*, valid XML ID character
+|_valid XML ID character_ +
+`*_*`
 |{y}
 |{n}
 |Word separator used in auto-generated section IDs.
 See xref:sections:id-prefix-and-separator.adoc#separator[Change the ID word separator].
 
 |leveloffset
+|{startsb}+-{endsb}0{endash}5
 |{n}
-|*0*, (+/-)0{en}5 (a leading + or - makes it relative)
-|{y}
-|{y}
+|{n}
 |Increases or decreases level of headings in include files.
+A leading + or - makes the value relative.
 //<<include-partitioning>>
 
 |partnums
+|_empty_
 |{n}
-|*_empty_*
-|{y}
 |{n}
 |See xref:sections:part-numbers-and-labels.adoc#partnums[Part numbers].
 _Book doctype only_.
 
 |sectanchors
-|{n}
 |_empty_
-|{y}
+|{n}
 |{n}
 |xref:sections:title-links.adoc#anchor[Adds anchor in front of section title] on mouse cursor hover.
 
 |sectids
-|{y}
 |*_empty_*
 |{y}
 |{n}
@@ -504,256 +476,258 @@ _Book doctype only_.
 See xref:sections:ids.adoc#disable[Disable ID generation].
 
 |sectlinks
-|{n}
 |_empty_
-|{y}
+|{n}
 |{n}
 |xref:sections:title-links.adoc[Turns section titles into self-referencing links].
 
 |sectnums
+|_empty_ +
+`all`
 |{n}
-|*_empty_*, all
-|{y}
 |{n}
 |xref:sections:numbers.adoc[Numbers sections] to depth specified by `sectnumlevels`.
 
 |sectnumlevels
-|Only if `sectnums` is set
-|*3*, 0{en}5
-|{y}
+|0{endash}5 +
+(3)
+|{n}
 |{n}
 |xref:sections:numbers.adoc#numlevels[Controls depth of section numbering].
 
 |title-separator
-|{y}
-|*:*, _any_
-|{y}
+|_any_
 |{n}
+|{y}
 |Character used to xref:document:subtitle.adoc[separate document title and subtitle].
 
 |toc
+|_empty_[=`auto`] +
+`auto` +
+`left` +
+`right` +
+`macro` +
+`preamble`
 |{n}
-|`*auto*`, `left`, `right`, `macro` or `preamble`
 |{y}
-|{n}
 |Turns on xref:toc:index.adoc[table of contents] and specifies xref:toc:position.adoc[its location].
 
 |toclevels
-|Only if `toc` is set
-|*2*, 1{en}5
-|{y}
+|1{endash}5 +
+(2)
 |{n}
+|{y}
 |xref:toc:section-depth.adoc[Maximum section level to display].
 
-// NOTE toc-placement moved to deprecated table in migration guide
-//|toc-placement
-//|Location where table of contents is inserted.
-//Should be treated as read-only.
-//|Based on value of `toc` attribute.
-//|auto, preamble, macro
-//|{y}
-//|
-
 |fragment
-|{n}
 |_empty_
-|
-|
+|{n}
+|{y}
 |Informs parser that document is a fragment and that it shouldn't enforce proper section nesting.
 |===
 
 == General content and formatting attributes
 
-[cols="10m,^15,15,^5,^5,30"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |Header Set |Body Set |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
 
 |asset-uri-scheme
+|_empty_ +
+`http` +
+(`https`)
 |{n}
-|`https`, _empty_
 |{y}
-|{n}
 |Controls protocol used for assets hosted on a CDN.
 
 |cache-uri
-|{n}
 |_empty_
-|{y}
 |{n}
+|{y}
 |Cache content read from URIs.
 //<<caching-uri-content>>
 
 |data-uri
-|{n}
 |_empty_
+|{n}
 |{y}
-|
 |Embed graphics as data-uri elements in HTML elements so file is completely self-contained.
 //<<managing-images>>
 
 |docinfo
+|_empty_[=`private`] +
+`shared` +
+`private` +
+`shared-head` +
+`private-head` +
+`shared-footer` +
+`private-footer`
 |{n}
-|`shared`, `private`, `shared-head`, `private-head`, `shared-footer`, `private-footer`
 |{y}
-|
 |Read input from one or more DocBook info files.
 //<<naming-docinfo-files>>
 
 |docinfodir
-|
-|*base directory*, _Directory_
+|_directory_ +
+(base directory)
+|{n}
 |{y}
-|
 |Location of docinfo files.
 //<<locating-docinfo-files>>
 
 |docinfosubs
-|
-|*attributes*, _comma-separated list of substitution names_
+|_comma-separated substitution names_ +
+(`attributes`)
+|{n}
 |{y}
-|
 |AsciiDoc substitutions that are applied to docinfo content.
 //<<attribute-substitution-in-docinfo-files>>
 
 |doctype
+|`*article*` +
+`book` +
+`inline` +
+`manpage`
 |{y}
-|`*article*`, `book`, `inline`, `manpage`
 |{y}
-|{n}
 |Output document type.
 //<<document-types>>
 
 |eqnums
+|_empty_[=`AMS`] +
+`AMS` +
+`all` +
+`none`
 |{n}
-|`*AMS*`, `all`, `none`
 |{y}
-|
 |Controls automatic equation numbering on LaTeX blocks in HTML output (MathJax).
 If the value is AMS, only LaTeX content enclosed in an `+\begin{equation}...\end{equation}+` container will be numbered.
 If the value is all, then all LaTeX blocks will be numbered.
 See https://docs.mathjax.org/en/v2.5-latest/tex.html#automatic-equation-numbering[equation numbering in MathJax].
 
 |hardbreaks-option
+|_empty_
 |{n}
-|*_empty_*
-|{y}
-|{y}
+|{n}
 |xref:blocks:hard-line-breaks.adoc#per-document[Preserve hard line breaks].
 
 |hide-uri-scheme
-|{n}
 |_empty_
-|{y}
-|
+|{n}
+|{n}
 |xref:macros:links.adoc#hide-uri-scheme[Hides URI scheme] for raw links.
 
 |media
+|`prepress` +
+`print` +
+(`screen`)
 |{n}
-|`*screen*`, `prepress`, `print`
 |{y}
-|
 |Specifies media type of output and enables behavior specific to that media type.
 _PDF converter only_.
 
 |nofooter
-|{n}
 |_empty_
+|{n}
 |{y}
-|
 |Turns off footer.
 //<<footer-docinfo-files>>
 
 |nofootnotes
-|{n}
 |_empty_
+|{n}
 |{y}
-|
 |Turns off footnotes.
 //<<user-footnotes>>
 
 |noheader
-|{n}
 |_empty_
+|{n}
 |{y}
-|
 |Turns off header.
 //<<doc-header>>
 
-|outfilesuffix
-|
-|_File extension_
+|notitle
+|_empty_
+|{n}
 |{y}
-|
+|xref:document:title.adoc#hide-or-show[Hides the doctitle in an embedded document].
+Mutually exclusive with the `showtitle` attribute.
+
+|outfilesuffix
+|*_file extension_*
+|{y}
+|{y}
 |File extension of output file, including dot (`.`), such as `.html`.
 // <<navigating-between-source-files>>
 
 |pagewidth
+|_integer_ +
+(425)
 |{n}
-|*425*, _integer_
 |{y}
-|
 |Page width used to calculate the absolute width of tables in the DocBook output.
 
 |relfileprefix
-|
-|_empty_, _path segment_
-|
-|
+|_empty_ +
+_path segment_
+|{n}
+|{n}
 |The path prefix to add to relative xrefs.
 //<<navigating-between-source-files>>
 
 |relfilesuffix
-|{y} _value of outfilesuffix_
-|Path segment
+|*_file extension_* +
+_path segment_
 |{y}
-|
+|{n}
 |The path suffix (e.g., file extension) to add to relative xrefs.
+Defaults to the value of the `outfilesuffix` attribute.
 (Preferred over modifying outfilesuffix).
 //|<<navigating-between-source-files>>
 
 |show-link-uri
-|{n}
 |_empty_
-|{y}
-|
+|{n}
+|{n}
 |Prints the URI of a link after the linked text.
 _PDF converter only_.
 
 |showtitle
-|{n}
 |_empty_
-|{y}
 |{n}
-|xref:document:title.adoc#hide-or-show[Displays an embedded document's title].
+|{y}
+|xref:document:title.adoc#hide-or-show[Displays the doctitle in an embedded document].
 Mutually exclusive with the `notitle` attribute.
 
 |stem
+|`_empty_`[=`asciimath`] +
+`asciimath` +
+`latexmath`
 |{n}
-|`*asciimath*`, `latexmath`
 |{y}
-|
 |Enables xref:stem:stem.adoc[mathematics processing and interpreter].
 
 |tabsize
+|_integer_ (≥ 0)
 |{n}
-|0 or more
-|{y}
-|{y}
+|{n}
 |Converts tabs to spaces in verbatim content blocks (e.g., listing, literal).
 
 |webfonts
-|{n}
-|_empty_ (use default fonts), Google Fonts collection spec
+|*_empty_*
 |{y}
-|{n}
+|{y}
 |Control whether webfonts are loaded, and which ones, when using the default stylesheet.
-The value populates the `family` query string parameter in the Google Fonts URL.
+When set to empty, uses the default font collection from Google Fonts.
+A non-empty value replaces the `family` query string parameter in the Google Fonts URL.
 //<<applying-a-theme>> and {url-org}/asciidoctor.org/issues/410[issue #410^]
 
 |xrefstyle
+|`full` +
+`short` +
+`basic`
 |{n}
-|`full`, `short`, `basic`
-|{y}
 |{n}
 |xref:macros:xref-text-and-style.adoc#cross-reference-styles[Formatting style to apply to cross reference text].
 //_Introduced in 1.5.6._
@@ -761,364 +735,348 @@ The value populates the `family` query string parameter in the Google Fonts URL.
 
 == Image and icon attributes
 
-[cols="10m,^15,15,^5,^5,30"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |Header Set |Body Set |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
 
 |iconfont-cdn
-|Only when `icons` attribute is set to `font`
-|_url_
-|{y}
+|_url_ +
+(default CDN URL)
 |{n}
+|{y}
 |If not specified, uses the cdnjs.com service.
 Overrides CDN used to link to the Font Awesome stylesheet.
 
 |iconfont-name
-|Only when `icons` attribute is set to `font`
-|_any_
+|_any_ +
+(`font-awesome`)
+|{n}
 |{y}
-|
 |Overrides the name of the icon font stylesheet.
-By default, this value is *font-awesome*.
 //<<icons>>
 
 |iconfont-remote
-|{n}
-|_empty_
+|*_empty_*
 |{y}
-|{n}
+|{y}
 |Allows use of a CDN for resolving the icon font.
-Only used when `icons` attribute is set to `font`.
+Only relevant used when value of `icons` attribute is `font`.
 
 |icons
+|_empty_[=`image`] +
+`image` +
+`font`
 |{n}
-|`*image*`, `font`
-|{y}
 |{y}
 |Chooses xref:macros:icons.adoc#icons-attribute[images or font icons] instead of text for admonitions.
+Any other value is assumed to be an icontype and sets the value to empty (image-based icons).
 
 |iconsdir
-|Only used when `icons` attribute is set to `image`
-|_Directory_
+|_directory_ +
+_url_
 |{y}
 |{n}
 |Location of non-font-based image icons.
 Points to the _icons_ folder under `imagesdir` by default.
 
 |icontype
-|Only used when `icons` attribute is set to `image`
-|`*png*`, `jpg`, `svg`, `gif`
-|{y}
+|`jpg` +
+(`png`) +
+`gif` +
+`svg`
+|{n}
 |{n}
 |File type for image icons.
+Only relevant when using image-based icons.
 
 |imagesdir
-|{y}
-|*_empty_*, _Directory_
+|_directory_ +
+_url_ +
+*_empty_*
 |{y}
 |{n}
 |Location of image files.
 |===
 
-== Code highlighting and formatting attributes
+== Source highlighting and formatting attributes
 
-[cols="10m,^15,15,^5,^5,30"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |Header Set |Body Set |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
 
 |coderay-css
-|
-|`*class*`, `style`
-|{y}
+|(`class`) +
+`style`
 |{n}
+|{y}
 |Controls whether CodeRay uses CSS classes or inline styles.
 
 |coderay-linenums-mode
-|
-|`*table*`, `inline`
-|{y}
+|`inline` +
+(`table`)
 |{n}
+|{y}
 |Sets how CodeRay inserts line numbers into source listings.
 
 |coderay-unavailable
-|
 |_empty_
-|{y}
 |{n}
+|{y}
 |Tells processor not to load CodeRay.
 
 |highlightjsdir
+|_directory_ +
+_url_ +
+(default CDN URL)
 |{n}
-|_Directory_
 |{y}
-|{n}
 |Location of the highlight.js source code highlighter library.
 
 |highlightjs-theme
-|
-|*github*, _highlight.js style name_
-|{y}
+|_highlight.js style name_ +
+(`github`)
 |{n}
+|{y}
 |Name of theme used by highlight.js.
 
 |prettifydir
+|_directory_ +
+_url_ +
+(default CDN URL)
 |{n}
-|_Directory_
 |{y}
-|{n}
 |Location of non-CDN prettify source code highlighter library.
 
 |prettify-theme
-|
-|*prettify*, _prettify style name_
-|{y}
+|_prettify style name_ +
+(`prettify`)
 |{n}
+|{y}
 |Name of theme used by prettify.
 
 |prewrap
+|*_empty_*
+|{y}
 |{n}
-|_empty_
-|{y}
-|{y}
 |xref:asciidoctor:html-backend:verbatim-line-wrap.adoc[Wrap wide code listings].
 
 |pygments-css
-|
-|`*class*`, `style`
-|{y}
+|(`class`) +
+`style`
 |{n}
+|{y}
 |Controls whether Pygments uses CSS classes or inline styles.
 
 |pygments-linenums-mode
-|
-|`*table*`, `inline`
-|{y}
+|(`table`) +
+`inline`
 |{n}
+|{y}
 |Sets how Pygments inserts line numbers into source listings.
 
 |pygments-style
-|
-|_Pygments style name_
-|{y}
+|_Pygments style name_ +
+(`default`)
 |{n}
+|{y}
 |Name of style used by Pygments.
 
 |pygments-unavailable
-|{n}
 |_empty_
-|{y}
 |{n}
+|{y}
 |Tells the processor not to load Pygments.
 
 |source-highlighter
+|`coderay` +
+`highlight.js` +
+`pygments` +
+`rouge`
 |{n}
-|`coderay`, `highlight.js`, `pygments`, `rouge`
 |{y}
-|{n}
 |xref:verbatim:source-highlighter.adoc[Specifies source code highlighter].
 Any other value is permitted, but must be supported by a custom syntax highlighter adapter.
 
 |source-indent
+|_integer_
 |{n}
-|_Integer_
-|{y}
-|{y}
+|{n}
 |Normalize block indentation in source code listings.
 //<<normalize-block-indentation>>
 
 |source-language
-|{n}
 |_Source code language name_
-|{y}
-|{y}
+|{n}
+|{n}
 |xref:verbatim:source-highlighter.adoc[Default language for source code blocks].
 
 |source-linenums-option
-|{n}
 |_empty_
-|{y}
-|{y}
+|{n}
+|{n}
 |Turns on line numbers for source code listings.
 //_Introduced in 1.5.6._
 |===
 
 == HTML styling attributes
 
-[cols="10m,^15,15,^5,^5,30"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |Header Set |Body Set |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
 
 |copycss
-|Only when `linkcss` is set
-|_empty_, location of the custom stylesheet (if used)
+|*_empty_* +
+_path_
 |{y}
-|{n}
+|{y}
 |Copy CSS files to output.
+Only relevant when the `linkcss` attribute is set.
 //<<applying-a-theme>>
 
 |css-signature
+|_valid XML ID_
 |{n}
-|_Valid XML ID_
 |{y}
-|{n}
 |Assign value to `id` attribute of HTML `<body>` element.
 *Preferred approach is to assign an ID to document title*.
 
 |linkcss
-|Only when safe mode is SECURE
 |_empty_
-|{y}
 |{n}
+|{y}
 |Links to stylesheet instead of embedding it.
 Can't be unset in SECURE mode.
 //<<styling-the-html-with-css>>
 
 |max-width
-|{n}
 |CSS length (e.g. 55em, 12cm, etc)
-|{y}
 |{n}
+|{y}
 |Constrains maximum width of document body.
 *Not recommended.
 Use CSS stylesheet instead.*
 
 |stylesdir
+|`*.*` +
+_directory_ +
+_url_
 |{y}
-|*. (Same directory as document)*, _Directory_
 |{y}
-|{n}
 |Location of CSS stylesheets.
 //<<creating-a-theme>>
 
 |stylesheet
+|*_empty_* +
+_file path_
 |{y}
-|*default stylesheet*, _file name_
 |{y}
-|{n}
 |CSS stylesheet file name.
+An empty value tells the converter to use the default stylesheet.
 //<<applying-a-theme>>
 
 |toc-class
-|
-|`*toc*`, valid CSS class name
-|{y}
+|_valid CSS class name_ +
+`*toc2*` or (`toc`)
 |{n}
+|{y}
 |CSS class on the table of contents container.
 //<<user-toc>>
 |===
 
 == Manpage attributes
 
-(relevant only when using the manpage doctype and/or converter)
+The attribute in this section are only relevant when using the manpage doctype and/or backend.
 
-[cols="10m,^15,15,^5,^5,30"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |Header Set |Body Set |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
 
 |mantitle
-|Based on content.
 |_any_
+|Based on content.
 |{y}
-|{n}
 |Metadata for man page output.
 //<<man-pages>>
 
 |manvolnum
-|Based on content.
 |_any_
+|Based on content.
 |{y}
-|{n}
 |Metadata for man page output.
 //<<man-pages>>
 
 |manname
-|Based on content.
 |_any_
+|Based on content.
 |{y}
-|{n}
 |Metadata for man page output.
 //<<man-pages>>
 
 |manpurpose
-|Based on content
 |_any_
+|Based on content
 |{y}
-|{n}
 |Metadata for man page output.
 //<<man-pages>>
 
 |man-linkstyle
-|
-|*blue R <>*, _link format sequence_
-|{y}
+|_link format pattern_ +
+(`blue R <>`)
 |{n}
+|{y}
 |Link style in man page output.
 //<<man-pages>>
 
 |mansource
-|{n}
 |_any_
-|{y}
 |{n}
+|{y}
 |Source (e.g., application and version) the man page describes.
 //<<man-pages>>
 
 |manmanual
-|{n}
 |_any_
-|{y}
 |{n}
+|{y}
 |Manual name displayed in the man page footer.
 //<<man-pages>>
 |===
 
 == Security attributes
 
-Most of the following attributes can only be set from the API or command line.
+Since these attributes deal with security, they can only be set from the API or CLI.
 
-[cols="20m,^15,15,^5,^5,25"]
+[cols="30m,20,^10,^10,30"]
 |===
-|Name |Automatically Set |Values |CLI |API |Notes
+.>|Name .>|Allowable Values .>|Set By Default .>|API/CLI Only .>|Notes
 
 |allow-uri-read
-|{n}
 |_empty_
-|{y}
+|{n}
 |{y}
 |Allows data to be read from URLs.
 //<<include-uri>>
 
 |max-attribute-value-size
-|
-|*4096* (SECURE mode only), 0 or greater
-|{y}
+|_integer_ (≥ 0) +
+*4096*
+|If safe mode is SECURE
 |{y}
 |Limits maximum size (in bytes) of a resolved attribute value.
+Default value is only set in SECURE mode.
 Since attributes can reference attributes, it's possible to create an output document disproportionately larger than the input document without this limit in place.
 
 |max-include-depth
-|
-|*64*, 0 or greater
-|{y}
+|_integer_ (≥ 0) +
+*64*
+|{n}
 |{y}
 |Curtail infinite include loops and to limit the opportunity to exploit nested includes to compound the size of the output document.
 //<<include-directive>>
-
-|skip-front-matter
-|{n}
-|_empty_
-|{y}
-|{y}
-|Consume YAML-style frontmatter at top of document and store it in `front-matter` attribute.
-//<<front-matter-added-for-static-site-generators>>
 |===
 
-^[1]^ The default value isn't necessarily the value you will get by entering `\{name}`.
-It may be the fallback value which Asciidoctor uses if the attribute is not defined.
-The effect is the same either way.
-
-[[note_blocknum]]^[2]^ The `-number` attributes are created and managed automatically by Asciidoctor for numbered blocks.
+[[fn-number]]^[1]^ The `-number` attributes are created and managed automatically by the AsciiDoc processor for numbered blocks.
 They are only used if the corresponding `-caption` attribute is set (e.g., `listing-caption`) and the block has a title.
-In the current version of Asciidoctor, setting the `-number` attributes will influence the number used for subsequent numbered blocks of that type.
+In Asciidoctor, setting the `-number` attributes will influence the number used for subsequent numbered blocks of that type.
 However, you should not rely on this behavior as it may change in future versions.
 // end::table[]


### PR DESCRIPTION
* rewrite intro
* fix incorrect values and descriptions
* consolidate Header Set and Body Set columns to Header Only
* resolves #1 indicate implied values separated from default values
* clarify difference between effective value and implied value
* update description of fields
* adjust column widths
* add several missing attributes
* move any above empty in legend for document attributes table
* remove outdated footnote and fix references to the remaining one 
* rename Values column to Allowable Values
* rename Header Only column for security attributes to CLI/API only
* configure content in table header to align to bottom