### PR TITLE
fix rendering of "\ifdef" in listing

### DIFF
--- a/modules/directives/pages/conditionals.adoc
+++ b/modules/directives/pages/conditionals.adoc
@@ -29,8 +29,10 @@ The conditional preprocessor directives determine which lines to add and which o
 
 If you don't want a conditional preprocessor directive to be processed, you must escape it using a backslash.
 
+// the following listing uses attributes to avoid the backslash to be removed before rendering it in HTML
+[source,subs=attributes+]
 ----
-\ifdef::just-an-example[]
+{backslash}ifdef::just-an-example[]
 ----
 
 Escaping the directive is necessary _even if it appears in a verbatim block_ since it's not aware of the surrounding document structure.


### PR DESCRIPTION
The current text renders like this: 

![image](https://user-images.githubusercontent.com/3957921/105760195-b8a8ec00-5f51-11eb-8e98-d2b5bc0ed4e6.png)

Instead it should render like this: 

![image](https://user-images.githubusercontent.com/3957921/105760388-058cc280-5f52-11eb-82e9-7b0c611b7b87.png)
