### PR TITLE
Update image example to show alt text containing spaces

### DIFF
--- a/docs/modules/macros/examples/image.adoc
+++ b/docs/modules/macros/examples/image.adoc
@@ -14,19 +14,19 @@ image::macros:sunset.jpg[]
 
 // in qr as syntax
 // tag::alt[]
-image::sunset.jpg[Sunset]
+image::sunset.jpg['Mesa Verde Sunset | by JAVH']
 // end::alt[]
 
 // in qr as result
 // tag::qr-alt[]
-image::macros:sunset.jpg[Sunset]
+image::macros:sunset.jpg['Mesa Verde Sunset | by JAVH']
 // end::qr-alt[]
 
 // tag::attr-co[]
 [#img-sunset] <.>
 .A mountain sunset <.>
 [link=https://www.flickr.com/photos/javh/5448336655] <.>
-image::sunset.jpg[Sunset,200,100] <.> <.>
+image::sunset.jpg['Mesa Verde Sunset | by JAVH',200,100] <.> <.>
 // end::attr-co[]
 
 // in qr as syntax
@@ -34,7 +34,7 @@ image::sunset.jpg[Sunset,200,100] <.> <.>
 .A mountain sunset
 [#img-sunset]
 [caption="Figure 1: ",link=https://www.flickr.com/photos/javh/5448336655]
-image::sunset.jpg[Sunset,200,100]
+image::sunset.jpg['Mesa Verde Sunset | by JAVH',200,100]
 // end::attr[]
 
 // in qr as result
@@ -42,7 +42,7 @@ image::sunset.jpg[Sunset,200,100]
 .A mountain sunset
 [#img-sunset]
 [caption="Figure 1: ",link=https://www.flickr.com/photos/javh/5448336655]
-image::macros:sunset.jpg[Sunset,200,100]
+image::macros:sunset.jpg['Mesa Verde Sunset | by JAVH',200,100]
 // end::qr-attr[]
 
 // in qr as syntax and result
@@ -66,12 +66,12 @@ Click image:macros:pause.png[title="Pause"] when you need a break.
 
 // in qr as syntax
 // tag::in-role[]
-image:sunset.jpg[Sunset,150,150,role=right] What a beautiful sunset!
+image:sunset.jpg['Mesa Verde Sunset | by JAVH',150,150,role=right] What a beautiful sunset!
 // end::in-role[]
 
 // in qr as result
 // tag::qr-role[]
-image:macros:sunset.jpg[Sunset,150,150,role=right] What a beautiful sunset!
+image:macros:sunset.jpg['Mesa Verde Sunset | by JAVH',150,150,role=right] What a beautiful sunset!
 // end::qr-role[]
 
 // tag::role[]

--- a/docs/modules/macros/pages/images.adoc
+++ b/docs/modules/macros/pages/images.adoc
@@ -44,7 +44,7 @@ include::example$image.adoc[tag=attr-co]
 <.> Assigns an ID to the block.
 <.> Defines the title of the block image, which gets displayed underneath the image when rendered.
 <.> `link` makes the image a link (this can also be defined inside the attribute list of the block macro)
-<.> The first positional attribute, _Sunset_, is the image's alt text.
+<.> The first positional attribute, _'Mesa Verde Sunset | by JAVH'_, is the image's alt text.
 <.> The second and third positional attributes define the width and height, respectively.
 
 The result of <<ex-attributes>> is displayed below.


### PR DESCRIPTION
The current image macro example only shows alt text that's a single word: 'sunset'. When you try to use this, and write real alt text containing spaces, you'll accidentally set all the positional parameters to subsequent words and things will generally not work, until you figure out that you need to quote it.

So, this updates the example text to 'Mesa Verde Sunset | by JAVH' - which is the alt text on the source flikr image and demonstrates how to write alt text with spaces in.