### PR TITLE
prevent rendering of "--" instead of "----" 

### DIFF
--- a/docs/modules/verbatim/examples/source.adoc
+++ b/docs/modules/verbatim/examples/source.adoc
@@ -12,7 +12,7 @@ end
 
 // tag::src-base-co[]
 [source#hello,ruby] <.> <.> <.>
----- <.>
+---- // <.>
 require 'sinatra'
 
 get '/hi' do


### PR DESCRIPTION
... by separating callout with a "//".

The currently rendered result at https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-highlighter/

![image](https://user-images.githubusercontent.com/3957921/119733178-71882480-be79-11eb-9933-51ea8c149876.png)

After the change: 

![image](https://user-images.githubusercontent.com/3957921/119733136-6208db80-be79-11eb-9dae-b4ab575709b1.png)


