### PR TITLE
add contexts

### DIFF
--- a/docs/modules/blocks/pages/index.adoc
+++ b/docs/modules/blocks/pages/index.adoc
@@ -81,6 +81,32 @@ The style extends the context to give it special behavior.
 NOTE: The context is what the converter uses to dispatch to a convert method.
 The style is used by the converter to apply special behavior to blocks of the same type.
 
+=== Valid block context names
+
+Asciidoctor's block types (or block contexts) include:
+
+* document
+* section
+* paragraph
+* image
+* dlist (description list)
+* ulist
+* olist
+* list_item
+* literal
+* listing
+* admonition
+* sidebar
+* example
+* open
+* pass (a passthrough block)
+* table
+* thematic_break (horizontal rule)
+* page_break
+
+NOTE: Links have the context 'paragraph'.
+
+
 == Block commonalities
 
 //Every block can have one or more lines of block metadata.


### PR DESCRIPTION
Proposal: add a list of valid contexts. Although the doc says they can be inferred from the asciidoc syntax, it is not always clear exactly what name to use (e.g. getting from description list to dlist has taken me a chunk of the afternoon, ending with me creating a doc with a lot of blocks and going through seeing what each context was called - I had been trying things like description_list)