### PR TITLE
Updates the complex URL partial file

### DIFF
--- a/docs/modules/macros/partials/ts-url-format.adoc
+++ b/docs/modules/macros/partials/ts-url-format.adoc
@@ -48,5 +48,7 @@ This URL has repeating underscores link:++https://asciidoctor.org/now_this__link
 ====
 
 For more information, see {url-org}/asciidoctor/issues/625[issue #625^].
+
+Note, if the URL contains eg. double quotes (`"`) and if you are using `asciidoctor-pdf` to generate pdf files, you will get _pdf build errors_. To fix this issue, replace the double quotes manually with `%22` (utf8-encoding).
 // end::sb[]
 --


### PR DESCRIPTION
Updates the complex URL partial file to address a pdf build error when using asciidoctor-pdf

Fixes: https://antora.zulipchat.com/#narrow/stream/282400-users/topic/.E2.9C.94.20Troubleshooting.20URL.20when.20having.20double.20quotes.20in.20the.20URL