### PR TITLE
Fix minor typos in attributes docs

### DIFF
--- a/docs/modules/attributes/pages/character-replacement-ref.adoc
+++ b/docs/modules/attributes/pages/character-replacement-ref.adoc
@@ -144,8 +144,8 @@ d|``wj``^[3]^
 
 Notice that some replacement values are Unicode characters, whereas others are numeric character references (e.g., \&#34;).
 The numeric character reference is when the Unicode character could interfere with the AsciiDoc syntax.
-In this case, it's the responsiblity of the converter to transform that numeric character reference into a format that is compatibile with the output format.
+In this case, it's the responsibility of the converter to transform that numeric character reference into a format that is compatible with the output format.
 For example, in the man page converter, each character reference is replaced with a troff macro.
 
 Thus, the abstraction of using AsciiDoc attributes for character replacements not only gives the author control over how the document is interpreted, it also helps decouple content and presentation.
-In other words, it's more protable to use an attribute reference in the content rather than hardcode a nummeric character reference.
+In other words, it's more portable to use an attribute reference in the content rather than hardcode a numeric character reference.

--- a/docs/modules/attributes/pages/id.adoc
+++ b/docs/modules/attributes/pages/id.adoc
@@ -206,7 +206,7 @@ include::example$id.adoc[tag=anchor-header-extra]
 
 CAUTION: You cannot use inline anchors in a section title to make internal references to that section.
 The processor will flag these as possible invalid references.
-These additional anchors are only intented for making deep links using an alternate ID.
+These additional anchors are only intended for making deep links using an alternate ID.
 
 Remember that inline anchors are discovered wherever the macro substitution is applied (e.g., paragraph text).
 If text content doesn't belong somewhere, neither does an inline anchor point.


### PR DESCRIPTION
Was closely reading these docs and stumbled onto a few minor typos.  So, a small PR to clean them up.