### PR TITLE
Added notice that GUI macros are fully supported

### DIFF
--- a/docs/modules/macros/pages/ui-macros.adoc
+++ b/docs/modules/macros/pages/ui-macros.adoc
@@ -2,6 +2,10 @@
 
 IMPORTANT: You must set the `experimental` attribute to enable the UI macros.
 
+IMPORTANT: In order to use the keyboard macro, you must set the `experimental` document attribute.
+Although this attribute is named `experimental`, the keyboard macro is considered a stable feature of the AsciiDoc language.
+The requirement to specify the attribute is merely an optimization for the processor.
+
 == Button macro syntax
 
 It can be difficult to communicate to the reader that they need to press a button.


### PR DESCRIPTION
The Keyboard macro has an IMPORTANT notice stating that the macro is fully supported. I understand that this is true for the GUI macros as well, so I added the same notice.