### PR TITLE
Fix external link shorthand example

### DIFF
--- a/docs/modules/macros/pages/link-macro-ref.adoc
+++ b/docs/modules/macros/pages/link-macro-ref.adoc
@@ -29,7 +29,7 @@ These attributes apply to the link, URL, and email macros.
 |`window` +
 (shorthand)
 |`^`
-|+https://example.org["Google, Yahoo, Bing^"]+ +
+|+https://example.org["Google, Yahoo, Bing"^]+ +
 +https://discuss.asciidoctor.org[Discuss Asciidoctor^]+
 |
 

--- a/docs/modules/macros/pages/link-macro-ref.adoc
+++ b/docs/modules/macros/pages/link-macro-ref.adoc
@@ -29,7 +29,7 @@ These attributes apply to the link, URL, and email macros.
 |`window` +
 (shorthand)
 |`^`
-|+https://example.org["Google, Yahoo, Bing"^]+ +
+|+https://example.org[Google, Yahoo, Bing^]+ +
 +https://discuss.asciidoctor.org[Discuss Asciidoctor^]+
 |
 


### PR DESCRIPTION
As the [docs say](https://docs.asciidoctor.org/asciidoc/latest/macros/link-macro-ref/), the caret (^) should be at the end of the link text. The current example produces `"Google, Yahoo, Bing^"`.