### PR TITLE
Fix wording about how to escape square brackets in keyboard macros

### DIFF
--- a/docs/modules/macros/pages/keyboard-macro.adoc
+++ b/docs/modules/macros/pages/keyboard-macro.adoc
@@ -18,7 +18,7 @@ It's customary to represent alpha keys in uppercase, though this is not enforced
 
 If the last key is a backslash (`\`), it must be followed by a space.
 Without this space, the processor will not recognize the macro.
-If one of the keys is a closing square bracket (`]`), it must be proceeded by a backslash.
+If one of the keys is a closing square bracket (`]`), it must be preceded by a backslash.
 Without the backslash escape, the macro will end prematurely.
 You can find example of these cases in the example below.
 


### PR DESCRIPTION
This looks like it was a typo, the slash needs to come before, not after, the square bracket.