### PR TITLE
UI Macros: Add admonition for menu first item's start character.

### DIFF
--- a/docs/modules/macros/pages/ui-macros.adoc
+++ b/docs/modules/macros/pages/ui-macros.adoc
@@ -1,7 +1,5 @@
 = Button and Menu UI Macros
 
-IMPORTANT: You must set the `experimental` attribute to enable the UI macros.
-
 IMPORTANT: In order to use the UI macros, you must set the `experimental` document attribute.
 Although this attribute is named `experimental`, the UI macros are considered a stable feature of the AsciiDoc language.
 The requirement to specify the attribute is merely an optimization for the processor.
@@ -57,3 +55,5 @@ include::example$ui.adoc[tag=menu-short]
 ----
 
 The shorthand syntax can be escaped by preceding the opening double quote with a backslash character.
+
+IMPORTANT: The first item in the menu must start with an alphanumeric character or an underscore (`_`). If you need the first menu item to start with a different character use the unicode code point or the HTML character reference.


### PR DESCRIPTION
Also removed the first admonition in the document, as it is redundant to the second admonition.